### PR TITLE
Add pytest tests for Flask backend

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import pytest
+
+# Ensure project root is on sys.path so "backend" imports work when running tests
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+BACKEND_DIR = os.path.join(ROOT_DIR, "backend")
+for path in (ROOT_DIR, BACKEND_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+from backend import app as app_module
+
+class TestLimiter(app_module.Limiter):
+    def __init__(self, *args, **kwargs):
+        kwargs['default_limits'] = ["2 per minute"]
+        super().__init__(*args, **kwargs)
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setattr(app_module, 'Limiter', TestLimiter)
+    application = app_module.create_app()
+    application.config['TESTING'] = True
+    return application
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -1,0 +1,24 @@
+from flask import url_for
+
+def test_health_endpoint(client):
+    res = client.get('/health')
+    assert res.status_code == 200
+    assert res.get_json()['status'] == 'ok'
+
+def test_ephemeris_positions(client):
+    res = client.get('/api/v1/ephemeris/positions')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert 'sun' in data
+
+
+def test_location_missing_address(client):
+    res = client.get('/api/v1/misc/location')
+    assert res.status_code == 400
+
+
+def test_rate_limiting(client):
+    for _ in range(2):
+        assert client.get('/api/v1/ephemeris/positions').status_code == 200
+    res = client.get('/api/v1/ephemeris/positions')
+    assert res.status_code == 429

--- a/backend/tests/test_ephemeris_service.py
+++ b/backend/tests/test_ephemeris_service.py
@@ -1,0 +1,17 @@
+import datetime
+from backend.services import ephemeris_service
+
+class FakeHorizons:
+    def __init__(self, id, location, epochs):
+        pass
+    def ephemerides(self):
+        return {"RA": [0], "DEC": [0]}
+
+def test_get_planetary_positions(monkeypatch):
+    monkeypatch.setattr(ephemeris_service, 'Horizons', FakeHorizons)
+    dt = datetime.datetime(2024, 1, 1)
+    positions = ephemeris_service.get_planetary_positions(dt)
+    assert set(positions.keys()) == set(ephemeris_service.PLANET_IDS.keys())
+    for data in positions.values():
+        assert data['sign'] == 'Aries'
+        assert 0 <= data['degree'] < 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = ["backend/tests"]


### PR DESCRIPTION
## Summary
- set up pytest configuration
- test ephemeris service logic with patched Horizons
- provide Flask test fixtures with lower rate limit
- add integration tests for health, ephemeris, and location endpoints
- check rate limiting behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844aafbf414832aa65dfb97ad7c2623