### PR TITLE
Implement chart generation with caching

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ anthropic>=0.25.0,<1.0.0
 pyswisseph>=2.10.0,<3.0.0
 astroquery>=0.4.0,<1.0.0
 astropy>=5.0.0,<6.0.0
+redis>=5.0.0,<6.0.0

--- a/backend/routes/chart.py
+++ b/backend/routes/chart.py
@@ -1,28 +1,110 @@
+from __future__ import annotations
+
+import base64
+import uuid
+from datetime import datetime
+
 from flask import Blueprint, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
 from utils.validators import validate_request
 from models.schemas import ChartRequest
+from services.astro_calculator import AstroCalculator
+from services.ephemeris_service import EphemerisService
+from services.chinese_astrology_service import ChineseAstrologyService
+from services.cloudkit_service import CloudKitService
+from services.redis_cache import get as redis_get, set as redis_set
 
 chart_bp = Blueprint('chart', __name__)
 
+astro = AstroCalculator()
+ephemeris = EphemerisService()
+chinese_service = ChineseAstrologyService()
+cloudkit = CloudKitService()
+
+
+def _chart_cache_key(system: str, req: ChartRequest) -> str:
+    b = req.birthData
+    return f"chart:{system}:{b.date}:{b.time}:{b.latitude}:{b.longitude}"
+
+
+def _svg_from_dict(title: str, data: dict) -> str:
+    lines = [
+        '<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">',
+        '<rect width="100%" height="100%" fill="white" stroke="black"/>',
+        f'<text x="10" y="20" font-size="16">{title} Chart</text>'
+    ]
+    y = 40
+    for key, val in data.items():
+        lines.append(f'<text x="10" y="{y}" font-size="12">{key}: {val}</text>')
+        y += 15
+    lines.append('</svg>')
+    return ''.join(lines)
+
+
 @chart_bp.route('/generate', methods=['POST'])
+@jwt_required(optional=True)
 @validate_request(ChartRequest)
 def generate(data: ChartRequest):
     try:
-        import uuid
+        birth = data.birthData
+        dt = datetime.fromisoformat(f"{birth.date}T{birth.time}")
+        systems = [s.lower() for s in data.systems]
+        results: dict[str, dict] = {}
+        user_id = get_jwt_identity()
+
+        for system in systems:
+            key = _chart_cache_key(system, data)
+            cached = redis_get(key)
+            if cached:
+                results[system] = cached
+                continue
+
+            if system == 'western':
+                positions = astro.western_chart(dt)
+                svg = _svg_from_dict('Western', {p: f"{v['sign']} {v['degree']}" for p, v in positions.items()})
+                chart = {
+                    'svg': base64.b64encode(svg.encode()).decode(),
+                    'positions': positions,
+                }
+            elif system == 'vedic':
+                positions = astro.vedic_chart(dt)
+                svg = _svg_from_dict('Vedic', {p: f"{v['sign']} {v['degree']}" for p, v in positions.items()})
+                chart = {
+                    'svg': base64.b64encode(svg.encode()).decode(),
+                    'positions': positions,
+                }
+            elif system == 'chinese':
+                cz = chinese_service.chart_for_date(dt.date())
+                svg = _svg_from_dict('Chinese', {'animal': cz.animal, 'element': cz.element, 'year': cz.year})
+                chart = {
+                    'svg': base64.b64encode(svg.encode()).decode(),
+                    'animal': cz.animal,
+                    'element': cz.element,
+                }
+            else:
+                continue
+
+            results[system] = chart
+            redis_set(key, chart)
+
+            if user_id:
+                cloudkit.save_birth_chart({
+                    'user_id': user_id,
+                    'system': system,
+                    'chart': chart
+                })
+
         chart_id = str(uuid.uuid4())
-        return jsonify({
-            'chartId': chart_id, 
-            'type': data.chartType,
-            'status': 'generated',
-            'mock': True
-        })
-    except Exception as e:
+        return jsonify({'chartId': chart_id, 'charts': results, 'type': data.chartType})
+    except Exception:
         return jsonify({'error': 'Chart generation failed'}), 500
+
 
 @chart_bp.route('/aspects', methods=['POST'])
 @validate_request(ChartRequest)
 def aspects(data: ChartRequest):
     try:
         return jsonify({'aspects': []})
-    except Exception as e:
+    except Exception:
         return jsonify({'error': 'Aspect calculation failed'}), 500

--- a/backend/services/astro_calculator.py
+++ b/backend/services/astro_calculator.py
@@ -1,0 +1,21 @@
+import datetime as _dt
+from typing import Dict
+
+from .ephemeris_service import get_planetary_positions
+
+AYANAMSA_OFFSET = 24  # rough offset for Vedic calculations
+
+class AstroCalculator:
+    """Simple wrapper around ephemeris calculations."""
+
+    def western_chart(self, dt: _dt.datetime) -> Dict[str, Dict[str, float]]:
+        """Return planetary positions for a western chart."""
+        return get_planetary_positions(dt)
+
+    def vedic_chart(self, dt: _dt.datetime) -> Dict[str, Dict[str, float]]:
+        """Return positions adjusted for Vedic astrology."""
+        positions = get_planetary_positions(dt)
+        for info in positions.values():
+            deg = (info["degree"] - AYANAMSA_OFFSET) % 30
+            info["degree"] = round(deg, 2)
+        return positions

--- a/backend/services/chinese_astrology_service.py
+++ b/backend/services/chinese_astrology_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+
+ANIMALS = [
+    "Rat",
+    "Ox",
+    "Tiger",
+    "Rabbit",
+    "Dragon",
+    "Snake",
+    "Horse",
+    "Goat",
+    "Monkey",
+    "Rooster",
+    "Dog",
+    "Pig",
+]
+
+ELEMENTS = ["Wood", "Fire", "Earth", "Metal", "Water"]
+
+@dataclass
+class ChineseChart:
+    animal: str
+    element: str
+    year: int
+
+class ChineseAstrologyService:
+    """Very small Chinese astrology helper."""
+
+    def chart_for_date(self, date: _dt.date) -> ChineseChart:
+        year = date.year
+        animal = ANIMALS[(year - 4) % 12]
+        element = ELEMENTS[((year - 4) // 2) % 5]
+        return ChineseChart(animal=animal, element=element, year=year)

--- a/backend/services/redis_cache.py
+++ b/backend/services/redis_cache.py
@@ -1,0 +1,33 @@
+import json
+import os
+from typing import Any, Optional
+
+import redis
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+try:
+    _client = redis.Redis.from_url(REDIS_URL)
+    _client.ping()
+except Exception:
+    _client = None
+
+
+def get(key: str) -> Optional[Any]:
+    if not _client:
+        return None
+    try:
+        val = _client.get(key)
+        if val is None:
+            return None
+        return json.loads(val)
+    except Exception:
+        return None
+
+
+def set(key: str, value: Any, ttl: int = 3600) -> None:
+    if not _client:
+        return
+    try:
+        _client.setex(key, ttl, json.dumps(value))
+    except Exception:
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ swisseph
 anthropic>=0.25.0,<1.0.0
 pyswisseph>=2.10.0,<3.0.0
 fpdf2>=2.7.0,<3.0.0
+redis>=5.0.0,<6.0.0


### PR DESCRIPTION
## Summary
- enable generation of Western, Vedic and Chinese charts
- new AstroCalculator and ChineseAstrologyService helpers
- add Redis based cache utilities
- encode SVG charts in base64 and optionally store via CloudKit
- update requirements for redis

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844aafae268832a8cadf9721d1352b1