### PR TITLE
Implement horoscope generation with caching

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -7,7 +7,7 @@ from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-from flask_caching import Cache
+from services.cache_service import cache
 
 from config import Config
 from routes.chat import chat_bp
@@ -19,8 +19,6 @@ from routes.ephemeris import ephemeris_bp
 from routes.locations import locations_bp
 from routes.misc import misc_bp
 from services.reports_service import ReportsService
-
-cache = Cache()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/backend/routes/horoscope.py
+++ b/backend/routes/horoscope.py
@@ -1,8 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime
 from flask import Blueprint, request, jsonify
 
+from services.astro_calculator import AstroCalculator
+from services.claude_ai import ClaudeService
+from services.cloudkit_service import CloudKitService
+from services.cache_service import cache
+
 horoscope_bp = Blueprint('horoscope', __name__)
+calculator = AstroCalculator()
+claude = ClaudeService()
+cloudkit = CloudKitService()
+
 
 @horoscope_bp.route('', methods=['GET'])
 def horoscope():
-    sign = request.args.get('sign', 'aries')
-    return jsonify({'sign': sign, 'horoscope': 'Today will be great!'})
+    sign = request.args.get('sign', 'aries').lower()
+    date_str = request.args.get('date')
+    type_ = request.args.get('type', 'daily').lower()
+
+    if date_str:
+        try:
+            dt = datetime.strptime(date_str, '%Y-%m-%d')
+        except ValueError:
+            return jsonify({'error': 'Invalid date format, use YYYY-MM-DD'}), 400
+    else:
+        dt = datetime.utcnow()
+        date_str = dt.strftime('%Y-%m-%d')
+
+    cache_key = f"horoscope:{sign}:{date_str}:{type_}"
+    cached = cache.get(cache_key)
+    if cached:
+        return jsonify(cached)
+
+    stored = cloudkit.get_horoscope(sign, date_str, type_)
+    if stored:
+        cache.set(cache_key, stored, timeout=3600)
+        return jsonify(stored)
+
+    positions = calculator.get_positions(dt)
+    position_lines = [
+        f"{planet.title()}: {info['sign']} {info['degree']}" for planet, info in positions.items()
+    ]
+    prompt = (
+        f"Generate a {type_} horoscope for the sign {sign.capitalize()} on {date_str}.\n"
+        "Use the following planetary positions:\n" + "\n".join(position_lines)
+    )
+    try:
+        content = claude.generate_content(prompt, max_tokens=300)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+    result = {'sign': sign, 'date': date_str, 'type': type_, 'horoscope': content}
+    cache.set(cache_key, result, timeout=3600)
+    cloudkit.save_horoscope(result)
+    return jsonify(result)

--- a/backend/services/astro_calculator.py
+++ b/backend/services/astro_calculator.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Any
+
+from .ephemeris_service import get_planetary_positions
+
+
+class AstroCalculator:
+    """Simple wrapper around ephemeris calculations."""
+
+    def get_positions(self, dt: datetime | None = None) -> Dict[str, Dict[str, Any]]:
+        """Return planetary positions for the given datetime."""
+        return get_planetary_positions(dt)


### PR DESCRIPTION
## Summary
- add `AstroCalculator` service wrapper around ephemeris calculations
- integrate horoscope route with AstroCalculator, ClaudeService, CloudKitService and caching
- use global `cache_service` in Flask app

## Testing
- `python -m py_compile backend/routes/horoscope.py backend/services/astro_calculator.py backend/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844aaf854d8832ab5e335fce55af7c5