### PR TITLE
Fix TestFlight upload pipeline for Xcode 26

### DIFF
--- a/.github/workflows/ios-distribution.yml
+++ b/.github/workflows/ios-distribution.yml
@@ -128,9 +128,8 @@ jobs:
             -authenticationKeyPath "$ASC_KEY_PATH" \
             -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_API_ISSUER_ID" \
-            CODE_SIGN_STYLE=Automatic \
-            DEVELOPMENT_TEAM=ZBSZPCY34Y \
-            CODE_SIGN_IDENTITY="Apple Distribution"
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
 
       - name: Export and upload to App Store Connect
         run: |

--- a/.github/workflows/ios-distribution.yml
+++ b/.github/workflows/ios-distribution.yml
@@ -111,8 +111,10 @@ jobs:
       - name: Prepare App Store Connect API key
         run: |
           mkdir -p private_keys
-          printf '%s' "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-          chmod 600 "private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          ASC_KEY_PATH="$PWD/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "$ASC_KEY_PATH"
+          chmod 600 "$ASC_KEY_PATH"
+          echo "ASC_KEY_PATH=$ASC_KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Archive release build
         run: |
@@ -122,7 +124,7 @@ jobs:
             -configuration Release \
             -archivePath "$RUNNER_TEMP/AstronovaApp.xcarchive" \
             -allowProvisioningUpdates \
-            -authenticationKeyPath "private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8" \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
             -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_API_ISSUER_ID"
 
@@ -132,6 +134,6 @@ jobs:
             -archivePath "$RUNNER_TEMP/AstronovaApp.xcarchive" \
             -exportOptionsPlist ExportOptions.plist \
             -allowProvisioningUpdates \
-            -authenticationKeyPath "private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8" \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
             -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_API_ISSUER_ID"

--- a/.github/workflows/ios-distribution.yml
+++ b/.github/workflows/ios-distribution.yml
@@ -127,7 +127,10 @@ jobs:
             -allowProvisioningUpdates \
             -authenticationKeyPath "$ASC_KEY_PATH" \
             -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
-            -authenticationKeyIssuerID "$APP_STORE_CONNECT_API_ISSUER_ID"
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_API_ISSUER_ID" \
+            CODE_SIGN_STYLE=Automatic \
+            DEVELOPMENT_TEAM=ZBSZPCY34Y \
+            CODE_SIGN_IDENTITY="Apple Distribution"
 
       - name: Export and upload to App Store Connect
         run: |

--- a/.github/workflows/ios-distribution.yml
+++ b/.github/workflows/ios-distribution.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   source-preflight:
     name: Source release preflight
-    runs-on: macos-14
+    runs-on: macos-26
     defaults:
       run:
         working-directory: client
@@ -30,7 +30,7 @@ jobs:
 
       - name: Select Xcode version
         run: |
-          sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
           xcodebuild -version
 
       - name: Validate export options
@@ -88,7 +88,7 @@ jobs:
 
   testflight-upload:
     name: TestFlight upload
-    runs-on: macos-14
+    runs-on: macos-26
     needs: source-preflight
     if: inputs.upload_to_testflight == true
     defaults:
@@ -105,7 +105,7 @@ jobs:
 
       - name: Select Xcode version
         run: |
-          sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
           xcodebuild -version
 
       - name: Prepare App Store Connect API key

--- a/.github/workflows/ios-distribution.yml
+++ b/.github/workflows/ios-distribution.yml
@@ -122,6 +122,7 @@ jobs:
             -project astronova.xcodeproj \
             -scheme AstronovaApp \
             -configuration Release \
+            -destination 'generic/platform=iOS' \
             -archivePath "$RUNNER_TEMP/AstronovaApp.xcarchive" \
             -allowProvisioningUpdates \
             -authenticationKeyPath "$ASC_KEY_PATH" \

--- a/client/AstronovaApp/Info.plist
+++ b/client/AstronovaApp/Info.plist
@@ -33,7 +33,7 @@
 		</dict>
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<true/>
+	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>Astronova needs camera access for video sessions during your bookings.</string>
 	<key>NSContactsUsageDescription</key>

--- a/client/ExportOptions.plist
+++ b/client/ExportOptions.plist
@@ -2,10 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>method</key>
-    <string>app-store-connect</string>
-    <key>teamID</key>
-    <string>ZBSZPCY34Y</string>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>teamID</key>
+	<string>ZBSZPCY34Y</string>
     <key>uploadSymbols</key>
     <true/>
     <key>destination</key>

--- a/client/astronova.xcodeproj/project.pbxproj
+++ b/client/astronova.xcodeproj/project.pbxproj
@@ -1103,9 +1103,7 @@
 				CURRENT_PROJECT_VERSION = 2026051601;
 				DEVELOPMENT_ASSET_PATHS = "\"AstronovaApp/Preview Content\"";
 				DEVELOPMENT_TEAM = ZBSZPCY34Y;
-				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
-				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = AstronovaApp/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
@@ -1139,9 +1137,7 @@
 				CURRENT_PROJECT_VERSION = 2026051601;
 				DEVELOPMENT_ASSET_PATHS = "\"AstronovaApp/Preview Content\"";
 				DEVELOPMENT_TEAM = ZBSZPCY34Y;
-				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
-				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = AstronovaApp/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";


### PR DESCRIPTION
## Summary
- Use an absolute App Store Connect API key path in the TestFlight workflow
- Archive on a generic iOS destination with unsigned archive + cloud signing export
- Remove macOS sandbox build settings from the iOS target
- Align export compliance declaration with App Store Connect
- Move upload workflow to the macOS 26 / Xcode 26 runner required by App Store Connect

## Verification
- Local Xcode 26.5 archive/export/upload succeeded for Astronova `1.0 / 2026051601` using App Store Connect API key `FTUF2YD2G3`
- App Store Connect accepted the upload and reported: `Uploaded package is processing` / `Upload succeeded`

No API key material is committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build and distribution pipeline configuration for improved compatibility with Xcode and App Store Connect.
  * Adjusted build settings and export options for the iOS app to support automated deployment workflows.
  * Updated app encryption declaration for App Store compliance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sankalpsthakur/astronova/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->