### PR TITLE
Prepare Astronova client and server for launch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -106,7 +106,7 @@ The `deploy-post-push-check.sh` script performs comprehensive endpoint validatio
 **Usage:**
 ```bash
 bash scripts/deploy-post-push-check.sh \
-  --base-url https://astronova.onrender.com \
+  --base-url https://astronova-ghcr.onrender.com \
   --wait-seconds 300 \
   --health-retries 30 \
   --health-delay 10
@@ -146,9 +146,10 @@ Add these secrets to your GitHub repository (Settings > Secrets and variables > 
    - Sign up at https://codecov.io
    - Get token from repository settings
 
-2. **RENDER_API_KEY** (Optional)
-   - For automatic deployments
-   - Get from Render dashboard > Account Settings > API Keys
+2. **RENDER_API_KEY** + **RENDER_SERVICE_ID** (or **RENDER_DEPLOY_HOOK_URL**)
+   - Required for `deploy.yml` staging/production jobs. The workflow now calls `scripts/render-deploy.sh` (Render resume + deploy) instead of skipping.
+   - Production URL is `https://astronova-ghcr.onrender.com` (the iOS client base URL). `astronova.onrender.com` is not a live service.
+   - Optional: `RENDER_STAGING_SERVICE_ID` / `RENDER_STAGING_DEPLOY_HOOK_URL` for staging.
 
 3. **ANTHROPIC_API_KEY** (Optional)
    - For Claude Code integration

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,24 +73,19 @@ jobs:
       url: https://astronova-staging.onrender.com
     env:
       RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+      RENDER_SERVICE_ID: ${{ secrets.RENDER_STAGING_SERVICE_ID }}
+      RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_STAGING_DEPLOY_HOOK_URL }}
+      RENDER_RESUME: "1"
+      ASTRONOVA_BASE_URL: https://astronova-staging.onrender.com
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Deploy to Render (Staging)
-        if: env.RENDER_API_KEY != ''
-        run: |
-          echo "::error::RENDER_API_KEY is configured, but this workflow still has no concrete Render deploy command."
-          echo "::error::Wire a Render deploy hook/API call before treating staging deployment as automated."
-          exit 1
-
-      - name: Skip staging deploy without Render credentials
-        if: env.RENDER_API_KEY == ''
-        run: echo "::notice::RENDER_API_KEY is not configured; staging deploy is intentionally skipped."
+        run: bash scripts/render-deploy.sh
 
       - name: Wait for deployment
-        if: env.RENDER_API_KEY != ''
         run: |
           echo "Running post-deploy verification for staging..."
           bash scripts/deploy-post-push-check.sh --base-url https://astronova-staging.onrender.com --wait-seconds 300 --health-retries 30 --health-delay 10
@@ -99,7 +94,7 @@ jobs:
         id: deployment-state
         if: always()
         run: |
-          if [ -n "$RENDER_API_KEY" ] && [ "${{ job.status }}" = "success" ]; then
+          if { [ -n "$RENDER_API_KEY" ] || [ -n "$RENDER_DEPLOY_HOOK_URL" ]; } && [ "${{ job.status }}" = "success" ]; then
             echo "deployed=true" >> "$GITHUB_OUTPUT"
           else
             echo "deployed=false" >> "$GITHUB_OUTPUT"
@@ -129,9 +124,13 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     environment:
       name: production
-      url: https://astronova.onrender.com
+      url: https://astronova-ghcr.onrender.com
     env:
       RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+      RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+      RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+      RENDER_RESUME: "1"
+      ASTRONOVA_BASE_URL: https://astronova-ghcr.onrender.com
 
     steps:
       - name: Checkout code
@@ -147,40 +146,26 @@ jobs:
             exit 1
           fi
 
-      - name: Create deployment backup
-        run: |
-          echo "Creating backup of current production state..."
-          # Add backup commands here
-
       - name: Deploy to Render (Production)
-        if: env.RENDER_API_KEY != ''
-        run: |
-          echo "::error::RENDER_API_KEY is configured, but this workflow still has no concrete Render deploy command."
-          echo "::error::Wire a Render deploy hook/API call before treating production deployment as automated."
-          exit 1
-
-      - name: Skip production deploy without Render credentials
-        if: env.RENDER_API_KEY == ''
-        run: echo "::notice::RENDER_API_KEY is not configured; production deploy is intentionally skipped."
+        run: bash scripts/render-deploy.sh
 
       - name: Wait for deployment
-        if: env.RENDER_API_KEY != ''
         run: |
           echo "Running post-deploy verification for production..."
-          bash scripts/deploy-post-push-check.sh --base-url https://astronova.onrender.com --wait-seconds 300 --health-retries 30 --health-delay 10
+          bash scripts/deploy-post-push-check.sh --base-url https://astronova-ghcr.onrender.com --wait-seconds 300 --health-retries 30 --health-delay 10
 
       - name: Record deployment state
         id: deployment-state
         if: always()
         run: |
-          if [ -n "$RENDER_API_KEY" ] && [ "${{ job.status }}" = "success" ]; then
+          if { [ -n "$RENDER_API_KEY" ] || [ -n "$RENDER_DEPLOY_HOOK_URL" ]; } && [ "${{ job.status }}" = "success" ]; then
             echo "deployed=true" >> "$GITHUB_OUTPUT"
           else
             echo "deployed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v') && env.RENDER_API_KEY != ''
+        if: startsWith(github.ref, 'refs/tags/v') && (env.RENDER_API_KEY != '' || env.RENDER_DEPLOY_HOOK_URL != '')
         run: |
           gh release create "${GITHUB_REF_NAME}" \
             --verify-tag \

--- a/client/AstronovaApp/AstronovaAppApp.swift
+++ b/client/AstronovaApp/AstronovaAppApp.swift
@@ -140,6 +140,7 @@ struct AstronovaAppApp: App {
                     switch newPhase {
                     case .active:
                         Self.startStoreKitObservationForForeground()
+                        Task { await authState.checkAPIConnectivity() }
                     case .background:
                         StoreKitManager.shared.stopSubscriptionStatusObservation()
                     case .inactive:

--- a/client/AstronovaApp/AuthState.swift
+++ b/client/AstronovaApp/AuthState.swift
@@ -199,11 +199,15 @@ class AuthState: ObservableObject {
                 if let networkError = error as? NetworkError {
                     switch networkError {
                     case .offline:
-                        self.connectionError = "Offline mode - some features may be limited"
+                        self.connectionError = "Offline mode — charts and chat need a connection."
                     case .timeout:
-                        self.connectionError = "Connection timeout - check your internet"
+                        self.connectionError = "Connection timeout — check your internet and retry."
+                    case .serverError(let code, _) where code == 503:
+                        self.connectionError = "The cosmic engine is waking up. Retry shortly."
                     case .serverError(let code, _):
-                        self.connectionError = "Server issue (\(code)) - please try again later"
+                        self.connectionError = "Server issue (\(code)) — please try again later."
+                    case .decodingError:
+                        self.connectionError = "The cosmic engine is temporarily unavailable. Retry shortly."
                     default:
                         self.connectionError = networkError.localizedDescription
                     }

--- a/client/AstronovaApp/RootView.swift
+++ b/client/AstronovaApp/RootView.swift
@@ -639,6 +639,21 @@ struct RootView: View {
                 SimpleTabBarView()
             }
         }
+        .overlay(alignment: .top) {
+            if auth.state != .loading, !auth.isAPIConnected, let message = auth.connectionError {
+                BackendStatusBanner(
+                    message: message,
+                    isRetrying: auth.isRetryingConnection
+                ) {
+                    Task { await auth.retryConnection() }
+                }
+                .padding(.top, 8)
+                .padding(.horizontal, Cosmic.Spacing.m)
+            }
+        }
+        .task {
+            await auth.checkAPIConnectivity()
+        }
         // Wave 13 — Global NPS sheet driver. Surfaces from NPSService after
         // Oracle session #5 or first Cosmic Diary entry (see NPSService).
         .sheet(isPresented: Binding(
@@ -657,6 +672,46 @@ struct RootView: View {
                 )
             }
         }
+    }
+}
+
+private struct BackendStatusBanner: View {
+    let message: String
+    let isRetrying: Bool
+    let onRetry: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: Cosmic.Spacing.s) {
+            Image(systemName: "wifi.exclamationmark")
+                .foregroundStyle(Color.cosmicGold)
+                .accessibilityHidden(true)
+            Text(message)
+                .font(.cosmicCaptionEmphasis)
+                .foregroundStyle(Color.cosmicTextPrimary)
+                .multilineTextAlignment(.leading)
+            Spacer(minLength: Cosmic.Spacing.s)
+            Button(action: onRetry) {
+                if isRetrying {
+                    ProgressView()
+                        .tint(Color.cosmicGold)
+                } else {
+                    Text("Retry")
+                        .font(.cosmicCaptionEmphasis)
+                }
+            }
+            .disabled(isRetrying)
+            .accessibilityIdentifier(AccessibilityID.retryConnectionButton)
+        }
+        .padding(.horizontal, Cosmic.Spacing.m)
+        .padding(.vertical, Cosmic.Spacing.s)
+        .background(Color.cosmicSurface.opacity(0.96))
+        .clipShape(RoundedRectangle(cornerRadius: Cosmic.Radius.card, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Cosmic.Radius.card, style: .continuous)
+                .stroke(Color.cosmicGold.opacity(0.35), lineWidth: Cosmic.Border.thin)
+        )
+        .accessibilityIdentifier(AccessibilityID.backendStatusBanner)
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/client/AstronovaApp/TestEnvironment.swift
+++ b/client/AstronovaApp/TestEnvironment.swift
@@ -513,4 +513,6 @@ enum AccessibilityID {
     static let errorMessage = "errorMessage"
     static let dismissButton = "dismissButton"
     static let doneButton = "doneButton"
+    static let backendStatusBanner = "backendStatusBanner"
+    static let retryConnectionButton = "retryConnectionButton"
 }

--- a/client/AstronovaAppTests/AstronovaAppTests.swift
+++ b/client/AstronovaAppTests/AstronovaAppTests.swift
@@ -157,6 +157,13 @@ final class AstronovaAppTests: XCTestCase {
         XCTAssertEqual(ShopCatalog.proPlan(for: ShopCatalog.defaultProProductID).title, "12-month plan")
     }
 
+    func testShopCatalogFallsBackToMonthlyWhenAnnualProductMissing() throws {
+        let available = Set([ShopCatalog.proMonthlyProductID])
+        let resolved = ShopCatalog.proPlans.first { available.contains($0.productId) }
+        XCTAssertEqual(resolved?.productId, ShopCatalog.proMonthlyProductID)
+        XCTAssertEqual(resolved?.billingPlan, .standard)
+    }
+
     func testReportsShopComponentContractSeparatesBuyAndIncludedStates() throws {
         let productIds = ShopCatalog.reports.map(\.productId)
         XCTAssertEqual(Set(productIds).count, productIds.count)

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -84,11 +84,23 @@ changes follow existing patterns but **need an Xcode build to verify**.
   correct as written.
 
 ### Needs human / external resources
+- **2026-08-19:** `https://astronova-ghcr.onrender.com` returns Render `suspend-by-user` (HTTP 503 HTML). Resume the `astronova-backend` service, then `workflow_dispatch` `deploy.yml` → production (requires `RENDER_DEPLOY_HOOK_URL` or `RENDER_API_KEY`+`RENDER_SERVICE_ID`). Confirm with `ASTRONOVA_BASE_URL=https://astronova-ghcr.onrender.com python server/scripts/check_production_security.py`.
 - Xcode build + TestFlight verification of all client changes.
-- Apple sandbox E2E: purchase → entitlement → refund.
-- Render env values: `APPLE_ROOT_CA_PEM`, webhook registration (templated in
-  `render.yaml`).
+- Apple sandbox E2E: purchase → entitlement → refund. Wire App Store Server Notifications to `https://astronova-ghcr.onrender.com/api/v1/payments/notifications`.
+- Render env values: `APPLE_ROOT_CA_PEM` (payments fail closed without it).
+- App Store Connect: complete `astronova_pro_12_month_commitment` metadata (#51). Client paywall already falls back to monthly if StoreKit omits the annual SKU.
+- GitHub TestFlight secrets (`APP_STORE_CONNECT_API_KEY_ID` / `ISSUER_ID` / `API_KEY_BASE64`) are already on the repo. Still missing Render deploy secrets: `RENDER_DEPLOY_HOOK_URL` or `RENDER_API_KEY`+`RENDER_SERVICE_ID`.
 - hi/ta/te/bn paywall translations.
+
+## Launch sequence (client + server)
+
+1. Resume Render `astronova-backend` (Dashboard → Resume, or `RENDER_RESUME=1` via `scripts/render-deploy.sh`).
+2. Confirm `/health` is JSON `{ "status": "ok" }` on `https://astronova-ghcr.onrender.com`.
+3. Run `python server/scripts/check_production_security.py` (tokenless Apple auth must be 401).
+4. Dispatch `.github/workflows/deploy.yml` with `environment=production` so main is live on GHCR.
+5. Dispatch `.github/workflows/ios-distribution.yml` with `upload_to_testflight=true` after ASC secrets are in GitHub.
+6. Sandbox: monthly Pro purchase → `/payments/verify` → restore; skip claiming annual until ASC metadata is READY_TO_SUBMIT.
+7. Submit for review only after `/privacy` and `/terms` load from the live GHCR host (the binary links those URLs).
 
 ## Accepted risks (deliberate decisions)
 - Sandbox transactions are accepted in production: App Review exercises

--- a/docs/app-store-readiness-todos.md
+++ b/docs/app-store-readiness-todos.md
@@ -32,11 +32,11 @@ without claiming a completed TestFlight upload or live App Store listing.
 
 ## Release Pipeline Notes
 - `client/ExportOptions.plist` is configured for App Store Connect upload with team ID `ZBSZPCY34Y`.
-- Release build settings currently use bundle ID `com.astronova.app`, marketing version `1.0`, build number `2026051601`, automatic signing, and team ID `ZBSZPCY34Y` for the app target.
+- Release build settings currently use bundle ID `com.astronova.app`, marketing version `1.0`, build number `2026053101`, automatic signing, and team ID `ZBSZPCY34Y` for the app target.
 - `.github/workflows/ios-distribution.yml` is manual and preflight-only by default. A real TestFlight upload is gated behind `upload_to_testflight=true` plus App Store Connect API key secrets.
-- No uploaded TestFlight build is confirmed here. Verify upload/build presence in App Store Connect before marking release status as complete.
-- No public App Store URL is confirmed here. Keep any store link hidden or marked pending until the Astronova listing is approved/live.
-- Remaining external gates: App Store Connect API key, Apple Developer team access, signing/provisioning/certificate availability for automatic signing, bundle ID/App ID ownership, App Store Connect app record availability, sandbox IAP records, reviewer/test account creation, support/privacy/terms URL verification, and acceptance of build `2026051601` or a later unique build number.
+- `.github/workflows/deploy.yml` now calls `scripts/render-deploy.sh` against `https://astronova-ghcr.onrender.com`. Add `RENDER_DEPLOY_HOOK_URL` or `RENDER_API_KEY`+`RENDER_SERVICE_ID`. The unused `astronova.onrender.com` host 404s.
+- Post-deploy verification runs `check_production_security.py` (tokenless Apple auth must 401) and no longer mints a JWT from `userIdentifier` alone.
+- Remaining external gates: resume the suspended Render service, add Render deploy secrets (`RENDER_DEPLOY_HOOK_URL` or `RENDER_API_KEY`+`RENDER_SERVICE_ID`), complete annual Pro metadata (#51), sandbox IAP, and live privacy/terms URLs on GHCR. ASC API key secrets are already present on the GitHub repo.
 - Request-correlation production proof remains open until a deployed request ID
   is verified in the configured log drain. `SECURITY-CLOUDKIT-ROTATION.md`
   remains an active owner-only secret-rotation gate; this pass did not inspect,

--- a/scripts/deploy-post-push-check.sh
+++ b/scripts/deploy-post-push-check.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-BASE_URL="https://astronova.onrender.com"
+BASE_URL="https://astronova-ghcr.onrender.com"
 WAIT_SECONDS=300
 REQUEST_TIMEOUT=25
 MAX_HEALTH_RETRIES=25
@@ -170,13 +170,21 @@ wait_for_health() {
     local attempt=1
     while (( attempt <= MAX_HEALTH_RETRIES )); do
         local status
-        status="$(curl -sS --max-time "$REQUEST_TIMEOUT" -o /tmp/astronova_health_check.txt -w "%{http_code}" "${BASE_URL}/api/v1/health" || true)"
+        local routing
+        status="$(curl -sS --max-time "$REQUEST_TIMEOUT" -D /tmp/astronova_health_headers.txt -o /tmp/astronova_health_check.txt -w "%{http_code}" "${BASE_URL}/health" || true)"
+        routing="$(awk -F': ' 'tolower($1)=="x-render-routing" {gsub(sprintf("%c",13),"",$2); print $2}' /tmp/astronova_health_headers.txt 2>/dev/null || true)"
         if [[ "${status//$'\n'/}" == "200" ]]; then
-            rm -f /tmp/astronova_health_check.txt
+            rm -f /tmp/astronova_health_check.txt /tmp/astronova_health_headers.txt
             return 0
         fi
 
-        rm -f /tmp/astronova_health_check.txt
+        if [[ "${routing}" == *suspend* ]] || grep -qi "Service Suspended" /tmp/astronova_health_check.txt 2>/dev/null; then
+            log "Render reports the service is suspended (${routing:-no routing header}). Resume it, then rerun."
+            rm -f /tmp/astronova_health_check.txt /tmp/astronova_health_headers.txt
+            return 1
+        fi
+
+        rm -f /tmp/astronova_health_check.txt /tmp/astronova_health_headers.txt
         attempt=$((attempt + 1))
         log "Health check attempt ${attempt}/${MAX_HEALTH_RETRIES} failed (status=$status); retrying in ${HEALTH_RETRY_DELAY}s."
         sleep "$HEALTH_RETRY_DELAY"
@@ -228,10 +236,20 @@ AUTH_USER_ID=""
 REPORT_ID=""
 
 if ! wait_for_health; then
-    die "Health endpoint never became available at ${BASE_URL}/api/v1/health"
+    die "Health endpoint never became available at ${BASE_URL}/health"
 fi
 
 record_result "Initial Health Check" 1 "healthy"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECURITY_CHECK="${SCRIPT_DIR}/../server/scripts/check_production_security.py"
+if [[ -f "$SECURITY_CHECK" ]]; then
+    if ASTRONOVA_BASE_URL="${BASE_URL}" python3 "$SECURITY_CHECK"; then
+        record_result "Production security smoke" 1 "passed"
+    else
+        record_result "Production security smoke" 0 "check_production_security.py failed"
+    fi
+fi
 
 # Public endpoint checks
 check_endpoint "System status" "GET" "/api/v1/system-status" "200" "__NO_BODY__" || true
@@ -268,55 +286,56 @@ check_endpoint "Location search" "GET" "/api/v1/location/search?q=New%20York" "2
 rm -f "$LAST_OUTPUT_FILE"
 
 # Auth + protected endpoints
-check_endpoint "Auth (Apple fallback)" "POST" "/api/v1/auth/apple" "200" '{"userIdentifier":"astronova-deploy-check","email":"deploy-check@astronova.app","firstName":"Deploy","lastName":"Checker"}' || true
-if [[ -f "$LAST_OUTPUT_FILE" ]]; then
-    AUTH_TOKEN="$(extract_json_field "$LAST_OUTPUT_FILE" "jwtToken" || true)"
-    AUTH_USER_ID="$(extract_json_field "$LAST_OUTPUT_FILE" "user.id" || true)"
+# Tokenless Apple Sign In must fail closed in production. Do not mint a JWT
+# from userIdentifier-only payloads (that was the stale-backend hole in #46).
+check_endpoint "Auth rejects tokenless Apple" "POST" "/api/v1/auth/apple" "401" '{"userIdentifier":"astronova-deploy-check","email":"deploy-check@astronova.app"}' || true
+rm -f "$LAST_OUTPUT_FILE"
+
+if [[ -n "${ASTRONOVA_DEPLOY_JWT:-}" && -n "${ASTRONOVA_DEPLOY_USER_ID:-}" ]]; then
+    AUTH_TOKEN="${ASTRONOVA_DEPLOY_JWT}"
+    AUTH_USER_ID="${ASTRONOVA_DEPLOY_USER_ID}"
+    AUTH_HEADERS=(
+        "Authorization: Bearer ${AUTH_TOKEN}"
+        "X-User-Id: ${AUTH_USER_ID}"
+    )
+    record_result "Auth payload parse" 1 "using ASTRONOVA_DEPLOY_JWT"
+
+    check_endpoint "Auth validate" "GET" "/api/v1/auth/validate" "200" "__NO_BODY__" "${AUTH_HEADERS[@]}" || true
     rm -f "$LAST_OUTPUT_FILE"
-    if [[ -n "$AUTH_TOKEN" && -n "$AUTH_USER_ID" ]]; then
-        AUTH_HEADERS=(
-            "Authorization: Bearer ${AUTH_TOKEN}"
-            "X-User-Id: ${AUTH_USER_ID}"
-        )
-        record_result "Auth payload parse" 1 "user_id=${AUTH_USER_ID}"
 
-        check_endpoint "Auth validate" "GET" "/api/v1/auth/validate" "200" "__NO_BODY__" "${AUTH_HEADERS[@]}" || true
-        rm -f "$LAST_OUTPUT_FILE"
+    check_endpoint "Subscription status" "GET" "/api/v1/subscription/status?userId=${AUTH_USER_ID}" "200" "__NO_BODY__" "${AUTH_HEADERS[@]}" || true
+    rm -f "$LAST_OUTPUT_FILE"
 
-        check_endpoint "Subscription status" "GET" "/api/v1/subscription/status?userId=${AUTH_USER_ID}" "200" "__NO_BODY__" "${AUTH_HEADERS[@]}" || true
-        rm -f "$LAST_OUTPUT_FILE"
-
-        if (( SKIP_CHAT == 0 )); then
-            expected_chat="200"
-            if (( ALLOW_CHAT_503 == 1 )); then
-                expected_chat="200,503"
-            fi
-            check_endpoint "Protected chat" "POST" "/api/v1/chat" "${expected_chat}" '{"message":"What is my cosmic trend today?","userId":"'"${AUTH_USER_ID}"'"}' "${AUTH_HEADERS[@]}" || true
-            rm -f "$LAST_OUTPUT_FILE"
+    if (( SKIP_CHAT == 0 )); then
+        expected_chat="200"
+        if (( ALLOW_CHAT_503 == 1 )); then
+            expected_chat="200,503"
         fi
+        check_endpoint "Protected chat" "POST" "/api/v1/chat" "${expected_chat}" '{"message":"What is my cosmic trend today?","userId":"'"${AUTH_USER_ID}"'"}' "${AUTH_HEADERS[@]}" || true
+        rm -f "$LAST_OUTPUT_FILE"
+    fi
 
-        if (( SKIP_CHARGED_REPORTS == 0 )); then
-            check_endpoint "Generate report" "POST" "/api/v1/reports/generate" "200,201" '{"reportType":"birth_chart","userId":"'"${AUTH_USER_ID}"'","birthData":{"date":"1990-01-15","time":"14:30","timezone":"America/New_York","latitude":40.7128,"longitude":-74.006}}' "${AUTH_HEADERS[@]}" || true
-            REPORT_ID="$(extract_json_field "$LAST_OUTPUT_FILE" "reportId" || true)"
-            if [[ -n "$REPORT_ID" ]]; then
-                record_result "Report id extraction" 1 "${REPORT_ID}"
-                rm -f "$LAST_OUTPUT_FILE"
+    if (( SKIP_CHARGED_REPORTS == 0 )); then
+        check_endpoint "Generate report" "POST" "/api/v1/reports/generate" "200,201,402" '{"reportType":"birth_chart","userId":"'"${AUTH_USER_ID}"'","birthData":{"date":"1990-01-15","time":"14:30","timezone":"America/New_York","latitude":40.7128,"longitude":-74.006}}' "${AUTH_HEADERS[@]}" || true
+        REPORT_ID="$(extract_json_field "$LAST_OUTPUT_FILE" "reportId" || true)"
+        if [[ -n "$REPORT_ID" ]]; then
+            record_result "Report id extraction" 1 "${REPORT_ID}"
+            rm -f "$LAST_OUTPUT_FILE"
 
-                check_endpoint "Reports list" "GET" "/api/v1/reports/user/${AUTH_USER_ID}" "200" "__NO_BODY__" "${AUTH_HEADERS[@]}" || true
-                rm -f "$LAST_OUTPUT_FILE"
+            check_endpoint "Reports list" "GET" "/api/v1/reports/user/${AUTH_USER_ID}" "200" "__NO_BODY__" "${AUTH_HEADERS[@]}" || true
+            rm -f "$LAST_OUTPUT_FILE"
 
-                check_endpoint "Report PDF" "GET" "/api/v1/reports/${REPORT_ID}/pdf" "200" "__NO_BODY__" || true
-                rm -f "$LAST_OUTPUT_FILE"
-            else
-                rm -f "$LAST_OUTPUT_FILE"
-                record_result "Report id extraction" 0 "missing reportId"
-            fi
+            check_endpoint "Report PDF" "GET" "/api/v1/reports/${REPORT_ID}/pdf" "200" "__NO_BODY__" || true
+            rm -f "$LAST_OUTPUT_FILE"
         else
-            record_result "Reports checks skipped" 1 "by flag"
+            rm -f "$LAST_OUTPUT_FILE"
+            record_result "Charged report (optional)" 1 "skipped — no reportId (expected without Pro)"
         fi
     else
-        record_result "Auth payload parse" 0 "jwtToken or user.id missing"
+        record_result "Reports checks skipped" 1 "by flag"
     fi
+else
+    record_result "Authenticated checks" 1 "skipped — set ASTRONOVA_DEPLOY_JWT to exercise paid paths"
 fi
 
 if (( FAILED_CHECKS > 0 )); then

--- a/scripts/render-deploy.sh
+++ b/scripts/render-deploy.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Trigger a Render deploy for Astronova (and optionally resume a suspended service).
+#
+# Required (one of):
+#   RENDER_DEPLOY_HOOK_URL
+#   RENDER_API_KEY + RENDER_SERVICE_ID
+#
+# Optional:
+#   RENDER_RESUME=1   POST /resume before deploying (needed after suspend-by-user)
+#   ASTRONOVA_BASE_URL  printed for operators; not used to trigger the deploy
+
+set -euo pipefail
+
+PROD_URL="${ASTRONOVA_BASE_URL:-https://astronova-ghcr.onrender.com}"
+
+log() {
+    printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$1"
+}
+
+die() {
+    log "ERROR: $1"
+    exit 1
+}
+
+if [[ -z "${RENDER_DEPLOY_HOOK_URL:-}" && ( -z "${RENDER_API_KEY:-}" || -z "${RENDER_SERVICE_ID:-}" ) ]]; then
+    die "Set RENDER_DEPLOY_HOOK_URL, or RENDER_API_KEY and RENDER_SERVICE_ID."
+fi
+
+if [[ "${RENDER_RESUME:-}" == "1" ]]; then
+    if [[ -z "${RENDER_API_KEY:-}" || -z "${RENDER_SERVICE_ID:-}" ]]; then
+        die "RENDER_RESUME=1 requires RENDER_API_KEY and RENDER_SERVICE_ID."
+    fi
+    log "Resuming Render service ${RENDER_SERVICE_ID} (no-op if already live)…"
+    curl -sS -X POST \
+        --max-time 30 \
+        -H "Authorization: Bearer ${RENDER_API_KEY}" \
+        -H "Accept: application/json" \
+        "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/resume" \
+        -o /tmp/render-resume.json \
+        -w "resume HTTP %{http_code}\n" || true
+fi
+
+if [[ -n "${RENDER_DEPLOY_HOOK_URL:-}" ]]; then
+    log "Triggering Render deploy hook for ${PROD_URL}"
+    curl -sS --fail-with-body -X POST --max-time 30 "${RENDER_DEPLOY_HOOK_URL}" \
+        -o /tmp/render-deploy.json \
+        -w "hook HTTP %{http_code}\n"
+elif [[ -n "${RENDER_API_KEY:-}" && -n "${RENDER_SERVICE_ID:-}" ]]; then
+    log "Triggering Render API deploy for service ${RENDER_SERVICE_ID}"
+    curl -sS --fail-with-body -X POST --max-time 30 \
+        -H "Authorization: Bearer ${RENDER_API_KEY}" \
+        -H "Accept: application/json" \
+        -H "Content-Type: application/json" \
+        -d '{"clearCache":"do_not_clear"}' \
+        "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys" \
+        -o /tmp/render-deploy.json \
+        -w "deploy HTTP %{http_code}\n"
+fi
+
+log "Render deploy requested. Wait for /health on ${PROD_URL} before treating launch as live."

--- a/server/app.py
+++ b/server/app.py
@@ -563,7 +563,14 @@ def create_app():
     @app.route("/health", methods=["GET"])
     @limiter.exempt
     def root_health():
-        return jsonify({"status": "ok"})
+        payload = {"status": "ok"}
+        commit = os.environ.get("RENDER_GIT_COMMIT") or os.environ.get("GIT_COMMIT")
+        if commit:
+            payload["commit"] = commit[:12]
+        service = os.environ.get("RENDER_SERVICE_NAME")
+        if service:
+            payload["service"] = service
+        return jsonify(payload)
 
     # Global error handlers
     @app.errorhandler(404)

--- a/server/config_validation.py
+++ b/server/config_validation.py
@@ -142,4 +142,8 @@ def readiness_report() -> dict:
         "ai_provider": {"ok": ai_ok, "detail": ai_msg},
     }
     ready = db_ok and eph_ok
-    return {"ready": ready, "checks": checks}
+    report = {"ready": ready, "checks": checks}
+    commit = os.environ.get("RENDER_GIT_COMMIT") or os.environ.get("GIT_COMMIT")
+    if commit:
+        report["commit"] = commit[:12]
+    return report

--- a/server/render.yaml
+++ b/server/render.yaml
@@ -31,6 +31,10 @@ services:
       # Set to the PEM contents of "Apple Root CA - G3" via the dashboard.
       - key: APPLE_ROOT_CA_PEM
         sync: false  # Set via Render dashboard (multi-line PEM)
+      # App Store Server Notifications V2 URL:
+      #   https://astronova-ghcr.onrender.com/api/v1/payments/notifications
+      # Configure this in App Store Connect → App → App Information →
+      # App Store Server Notifications (Production + Sandbox).
       # Shared rate-limit store. Only needed if you scale to multiple workers/
       # instances; with the single-process start command below, in-memory is
       # fine. Set to a redis:// URL when scaling.

--- a/server/scripts/check_production_security.py
+++ b/server/scripts/check_production_security.py
@@ -60,12 +60,40 @@ def check(condition: bool, passed: str, failed: str, failures: list[str]) -> Non
         failures.append(failed)
 
 
+def is_render_suspended(response: Response) -> bool:
+    routing = (response.headers.get("X-Render-Routing") or response.headers.get("x-render-routing") or "").lower()
+    if "suspend" in routing:
+        return True
+    text = response.body.decode("utf-8", errors="replace").lower()
+    return response.status == 503 and "service suspended" in text
+
+
 def main() -> int:
     failures: list[str] = []
     print(f"Checking Astronova production security at {BASE_URL.rstrip('/')}")
 
     health = fetch("/health")
+    if is_render_suspended(health):
+        check(
+            False,
+            "",
+            "GET /health is Render suspend-by-user HTML, not JSON. Resume astronova-backend before launch.",
+            failures,
+        )
+        print(f"\n{len(failures)} production security check(s) failed.")
+        return 1
     check(health.status == 200, "GET /health returns 200", f"GET /health returned {health.status}", failures)
+    if health.status == 200:
+        try:
+            payload = json.loads(health.body.decode("utf-8"))
+        except json.JSONDecodeError:
+            payload = {}
+        check(
+            payload.get("status") == "ok",
+            "GET /health returns JSON status=ok",
+            "GET /health 200 body is not JSON {status: ok}",
+            failures,
+        )
 
     admin_list = fetch("/api/v1/admin/list-users?limit=1")
     check(
@@ -140,6 +168,27 @@ def main() -> int:
         "localhost CORS origin is allowed by production",
         failures,
     )
+
+    api_health = fetch("/api/v1/health")
+    check(
+        api_health.status == 200,
+        "GET /api/v1/health returns 200",
+        f"GET /api/v1/health returned {api_health.status}",
+        failures,
+    )
+
+    webhook = fetch("/api/v1/payments/notifications", method="POST", json_body={})
+    check(
+        webhook.status == 400,
+        "POST /api/v1/payments/notifications rejects empty payload",
+        f"POST /api/v1/payments/notifications returned {webhook.status}",
+        failures,
+    )
+
+    privacy = fetch("/privacy")
+    terms = fetch("/terms")
+    check(privacy.status == 200, "GET /privacy is live", f"GET /privacy returned {privacy.status}", failures)
+    check(terms.status == 200, "GET /terms is live", f"GET /terms returned {terms.status}", failures)
 
     if failures:
         print(f"\n{len(failures)} production security check(s) failed.")

--- a/server/tests/test_config_and_readiness.py
+++ b/server/tests/test_config_and_readiness.py
@@ -64,3 +64,18 @@ def test_readiness_endpoint(client):
     assert "ready" in body and "checks" in body
     # Database must be healthy in the test environment.
     assert body["checks"]["database"]["ok"] is True
+
+
+def test_root_health_includes_commit_when_configured(client, monkeypatch):
+    monkeypatch.setenv("RENDER_GIT_COMMIT", "abcdef1234567890")
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert body["commit"] == "abcdef123456"
+
+
+def test_readiness_includes_commit_when_configured(monkeypatch):
+    monkeypatch.setenv("GIT_COMMIT", "deadbeefcafebabe")
+    report = readiness_report()
+    assert report["commit"] == "deadbeefcafe"


### PR DESCRIPTION
Prepares Astronova **client and server** for launch.

**Server**
- `scripts/render-deploy.sh` resumes a suspended Render service and triggers a deploy hook or Render API deploy.
- `deploy.yml` no longer stubs/skips: production URL is `https://astronova-ghcr.onrender.com` (the iOS client host). `astronova.onrender.com` 404s.
- `/health` and `/api/v1/readiness` include Render commit SHA when present.
- Post-deploy checks fail closed on tokenless Apple auth (#46), detect Render `suspend-by-user`, and require live `/privacy` + `/terms`.

**Client**
- Retryable backend-down banner when GHCR is 503/HTML (App Review no longer gets a blank screen).
- Re-check API connectivity when the scene becomes active.
- Shop catalog test covers monthly fallback if annual Pro metadata is missing (#51).

**Operator (required before TestFlight/review)**
1. Add GitHub secrets: `RENDER_DEPLOY_HOOK_URL` or `RENDER_API_KEY` + `RENDER_SERVICE_ID` (ASC keys are already on the repo).
2. Resume Render `astronova-backend` (currently 503 suspend-by-user).
3. Merge this PR, then dispatch `deploy.yml` → production.
4. Dispatch `ios-distribution.yml` with `upload_to_testflight=true`.
5. Complete annual Pro metadata in App Store Connect (#51); paywall already falls back to monthly.
6. Wire ASSN to `https://astronova-ghcr.onrender.com/api/v1/payments/notifications` and set `APPLE_ROOT_CA_PEM` on Render.

Related: #46 #47 #48 #49 #51